### PR TITLE
fix(pages): use correct vertical spacing on welcome text

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -42,7 +42,7 @@ const Home: NextPage = () => {
                 alt="Heart emoji"
               ></Image>
             </div>
-            <div className="space-yCleanShot 2022-08-14 at 16.11.50@2x.png-2 justify-center text-center text-gray-900 dark:text-white">
+            <div className="space-y-2 justify-center text-center text-gray-900 dark:text-white">
               <div className="text-2xl font-semibold ">
                 Welcome to Stardew.app!{" "}
                 <Image


### PR DESCRIPTION
Someone copied and pasted a file name into the code, causing the spacing to be messed up 🙈 