### PR TITLE
fix(farmer.tsx): update stardrop counts when manually updating

### DIFF
--- a/components/cards/achievementcard.tsx
+++ b/components/cards/achievementcard.tsx
@@ -1,19 +1,24 @@
-import { CheckCircleIcon } from "@heroicons/react/outline";
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
+import { useKV } from "../../hooks/useKV";
 import { motion } from "framer-motion";
 import Image from "next/image";
-import { useCallback, useEffect, useState } from "react";
-
-import { useKV } from "../../hooks/useKV";
 
 interface Props {
   id: number | string;
   title: string;
   description: string;
-  additionalDescription?: string;
   sourceURL: string;
   tag: string;
+  additionalDescription?: string;
   initialChecked?: boolean;
   size?: number;
+  setCount?: Dispatch<SetStateAction<number>>;
 }
 
 function useSingleAndDoubleClick(
@@ -49,6 +54,7 @@ const AchievementCard = ({
   initialChecked,
   tag,
   size,
+  setCount,
 }: Props) => {
   const [truncate, setTruncate] = useState(true);
   const [checked, setChecked] = useKV<boolean>(
@@ -60,6 +66,9 @@ const AchievementCard = ({
     setTruncate((old) => !old);
   }, []);
   const twoClick = useCallback(() => {
+    if (checked) setCount?.((prev: number) => prev - 1);
+    else setCount?.((prev: number) => prev + 1);
+
     setChecked((old) => !old);
   }, [setChecked]);
 

--- a/pages/farmer.tsx
+++ b/pages/farmer.tsx
@@ -78,7 +78,7 @@ const Farmer: NextPage = () => {
   const [moneyEarned] = useKV<number>("general", "moneyEarned", 0);
   const [farmerLevel] = useKV<number>("levels", "player", 0);
   const [questsCompleted] = useKV<number>("general", "questsCompleted", 0);
-  const [stardropsCount] = useKV<number>("stardrops", "count", 0);
+  const [stardropsCount, setStarCount] = useKV<number>("stardrops", "count", 0);
 
   const [maxLevelCount] = useKV<number>("levels", "maxLevelCount", 0);
 
@@ -301,6 +301,7 @@ const Farmer: NextPage = () => {
                     description={
                       STARDROPS[stardrop as keyof typeof STARDROPS].description
                     }
+                    setCount={setStarCount}
                   />
                 ))}
               </div>


### PR DESCRIPTION
![demo](https://media.giphy.com/media/8Z0b79BBmIA8jADlhj/giphy.gif)

Should be working as intended, I rewrote the `AchievementCard` component to take an optional `setCount()` prop.