### PR TITLE
Removed duplicate text

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -143,12 +143,6 @@ const Home: NextPage = () => {
                   Additionally, you can login with Discord to save your data
                   across devices.
                 </h2>
-                {!user && (
-                  <h2>
-                    You can also login with Discord to save your data across
-                    devices.
-                  </h2>
-                )}
               </div>
               <div
                 className={classNames("dragAndDropWrapper", {


### PR DESCRIPTION
On the home page, there is a text saying you can log in with discord to save your data across devices.
Below that, there is another text saying the exact same thing which is shown if you're not logged in.
This PR removes the second text which is only shown if the user isn't logged in.